### PR TITLE
Merge 1.0.4 from davisp/jiffy

### DIFF
--- a/c_src/encoder.c
+++ b/c_src/encoder.c
@@ -166,6 +166,10 @@ enc_ensure(Encoder* e, size_t req)
         if(!enc_flush(e)) {
             return 0;
         }
+
+        if(e->have_buffer) {
+            return 1;
+        }
     }
 
     for(new_size = BIN_INC_SIZE; new_size < req; new_size <<= 1);

--- a/src/jiffy.app.src
+++ b/src/jiffy.app.src
@@ -1,6 +1,6 @@
 {application, jiffy, [
     {description, "JSON Decoder/Encoder."},
-    {vsn, "1.0.3"},
+    {vsn, "1.0.4"},
     {registered, []},
     {applications, [kernel, stdlib, xmerl]},
     {maintainers, ["Paul J. Davis"]},


### PR DESCRIPTION
- Fix binary leak when encoding large strings